### PR TITLE
Migration rollback does not properly drop the trigger

### DIFF
--- a/lib/ecto_job/migrations.ex
+++ b/lib/ecto_job/migrations.ex
@@ -69,7 +69,7 @@ defmodule EctoJob.Migrations do
     Drops the job queue table with the given name, and associated trigger
     """
     def down(name) do
-      execute("DROP FUNCTION tr_notify_inserted_#{name}()")
+      execute("DROP TRIGGER tr_notify_inserted_#{name} ON #{name}")
       execute("DROP TABLE #{name}")
     end
   end


### PR DESCRIPTION
A migration rollback was failing because it was trying to drop a non-existent function.  It appears that we should be trying to drop the trigger created in `up` instead.