### PR TITLE
Customizable job polling interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,13 @@ defmodule MyApp.JobQueue do
   ...
 end
 ```
+### Options
 
+You can customize how often the table is polled for scheduled jobs.  The default is 60_000 ms.
+
+```
+config :ecto_job, :poll_interval, 15_000
+```
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ end
 ```
 ### Options
 
-You can customize how often the table is polled for scheduled jobs.  The default is 60_000 ms.
+You can customize how often the table is polled for scheduled jobs.  The default is `60_000` ms.
 
 ```
 config :ecto_job, :poll_interval, 15_000

--- a/lib/ecto_job/producer.ex
+++ b/lib/ecto_job/producer.ex
@@ -72,7 +72,7 @@ defmodule EctoJob.Producer do
   # Starts the sweeper timer to activate scheduled/expired jobs
   @spec start_timer() :: {:ok, :timer.tref()}
   defp start_timer do
-    {:ok, _ref} = :timer.send_interval(60_000, :poll)
+    {:ok, _ref} = :timer.send_interval(Application.get_env(:ecto_job, :poll_interval, 60_000), :poll)
   end
 
   # Starts listening to notifications from postgrex for new jobs


### PR DESCRIPTION
Hi again!

I'd love to be able to control the frequency with which the table is polled for scheduled jobs.  Nice to be much more granular in production and much less in development.

Example:

```
config :ecto_job, :poll_interval, 15_000
```

Thanks for your consideration!

