### PR TITLE
Optional logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ You can customize how often the table is polled for scheduled jobs.  The default
 config :ecto_job, :poll_interval, 15_000
 ```
 
+You can disable the log messages sent when a job completes.  The default is that they are enabled.
+
+```
+config :ecto_job, :disable_logging, true
+```
+
 ## How it works
 
 Each job queue is represented as a PostgreSQL table and Ecto schema.

--- a/README.md
+++ b/README.md
@@ -152,10 +152,11 @@ You can customize how often the table is polled for scheduled jobs.  The default
 config :ecto_job, :poll_interval, 15_000
 ```
 
-You can disable the log messages sent when a job completes.  The default is that they are enabled.
+You can control whether logs are on or off and the log level.  The default is true and info.
 
 ```
-config :ecto_job, :disable_logging, true
+config :ecto_job, log: true,
+                  log_level: :debug
 ```
 
 ## How it works

--- a/lib/ecto_job/worker.ex
+++ b/lib/ecto_job/worker.ex
@@ -32,7 +32,9 @@ defmodule EctoJob.Worker do
   @spec log_duration(EctoJob.JobQueue.job(), DateTime.t()) :: :ok
   defp log_duration(_job = %queue{id: id}, start = %DateTime{}) do
     duration = DateTime.diff(DateTime.utc_now(), start, :microseconds)
-    Logger.info("#{queue}[#{id}] done: #{duration} µs")
+    if Application.get_env(:ecto_job, :disable_logging, false) do
+      Logger.info("#{queue}[#{id}] done: #{duration} µs")
+    end
   end
 
   @spec notify_completed(repo, EctoJob.JobQueue.job()) :: :ok

--- a/lib/ecto_job/worker.ex
+++ b/lib/ecto_job/worker.ex
@@ -32,8 +32,9 @@ defmodule EctoJob.Worker do
   @spec log_duration(EctoJob.JobQueue.job(), DateTime.t()) :: :ok
   defp log_duration(_job = %queue{id: id}, start = %DateTime{}) do
     duration = DateTime.diff(DateTime.utc_now(), start, :microseconds)
-    if Application.get_env(:ecto_job, :disable_logging, false) do
-      Logger.info("#{queue}[#{id}] done: #{duration} µs")
+    if Application.get_env(:ecto_job, :log, true) do
+      level = Application.get_env(:ecto_job, :log_level, :info)
+      Logger.log(level, fn -> "#{queue}[#{id}] done: #{duration} µs" end)
     end
   end
 


### PR DESCRIPTION
I have another config request - I'd like to be able to disable the logging.  We are up to running tens of thousands of jobs per hour, and we are starting to have to watch how much data we're logging in general because we're sending stuff out to third party log analysis services.

I was on the fence about `disable_logging: true` vs `enable_logging: false`, but it seemed since enabled is the default, it should stay that way.