### PR TITLE
Add configuration struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,14 @@ You can customize how often the table is polled for scheduled jobs.  The default
 config :ecto_job, :poll_interval, 15_000
 ```
 
-You can control whether logs are on or off and the log level.  The default is true and info.
+You can control whether logs are on or off and the log level.  The default is `true` and `:info`.
 
 ```
 config :ecto_job, log: true,
                   log_level: :debug
 ```
+
+See `EctoJob.Config` for configuration details.
 
 ## How it works
 

--- a/examples/async_job_api/mix.lock
+++ b/examples/async_job_api/mix.lock
@@ -1,13 +1,15 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "db_connection": {:hex, :db_connection, "1.1.2", "2865c2a4bae0714e2213a0ce60a1b12d76a6efba0c51fbda59c9ab8d1accc7a8", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
-  "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [], [], "hexpm"},
+  "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.7", "2074106ff4a5cd9cb2b54b12ca087c4b659ddb3f6b50be4562883c1d763fb031", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.13.0", "09c85d9939d4dce88e8819fd235ce411990abaf1bc24bd5a824e851439aedc15", [:mix], [], "hexpm"},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.13.3", "c277cfb2a9c5034d445a722494c13359e361d344ef6f25d604c2353185682bfc", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
-  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"}}
+  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
+}

--- a/examples/ecto_job_demo/lib/ecto_job_demo/cli.ex
+++ b/examples/ecto_job_demo/lib/ecto_job_demo/cli.ex
@@ -10,7 +10,7 @@ defmodule EctoJobDemo.CLI do
 
   defp enqueue_jobs(n, "ecto_job") do
     Enum.each(1..n, fn i ->
-      {EctoJobDemo, :hello, [i]}
+      %{hello: i}
       |> EctoJobDemo.JobQueue.new()
       |> EctoJobDemo.Repo.insert!()
     end)

--- a/examples/ecto_job_demo/lib/ecto_job_demo/job_queue.ex
+++ b/examples/ecto_job_demo/lib/ecto_job_demo/job_queue.ex
@@ -1,3 +1,7 @@
 defmodule EctoJobDemo.JobQueue do
   use EctoJob.JobQueue, table_name: "jobs"
+
+  def perform(multi, %{"hello" => name}) do
+    EctoJobDemo.hello(multi, name)
+  end
 end

--- a/examples/ecto_job_demo/mix.lock
+++ b/examples/ecto_job_demo/mix.lock
@@ -1,11 +1,13 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
-  "db_connection": {:hex, :db_connection, "1.1.2", "2865c2a4bae0714e2213a0ce60a1b12d76a6efba0c51fbda59c9ab8d1accc7a8", [], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
-  "decimal": {:hex, :decimal, "1.4.0", "fac965ce71a46aab53d3a6ce45662806bdd708a4a95a65cde8a12eb0124a1333", [], [], "hexpm"},
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "db_connection": {:hex, :db_connection, "1.1.2", "2865c2a4bae0714e2213a0ce60a1b12d76a6efba0c51fbda59c9ab8d1accc7a8", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.4.0", "fac965ce71a46aab53d3a6ce45662806bdd708a4a95a65cde8a12eb0124a1333", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.6", "3fd1067661d6d64851a0d4db9acd9e884c00d2d1aa41cc09da687226cf894661", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
-  "exq": {:hex, :exq, "0.9.0", "3feeb085fcd94a687033211e10c78cf9dca1de062aac3fa9a4b1f808cdcea522", [], [{:poison, ">= 1.2.0 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}, {:redix, ">= 0.5.0", [hex: :redix, repo: "hexpm", optional: false]}, {:uuid, ">= 1.0.0", [hex: :uuid, repo: "hexpm", optional: false]}], "hexpm"},
-  "gen_stage": {:hex, :gen_stage, "0.12.1", "63899782173e4d9247f0a2f697a1cd72c3f255267d84449c56138f8514733103", [], [], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [], [], "hexpm"},
-  "postgrex": {:hex, :postgrex, "0.13.3", "c277cfb2a9c5034d445a722494c13359e361d344ef6f25d604c2353185682bfc", [], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
-  "redix": {:hex, :redix, "0.6.1", "20986b0e02f02b13e6f53c79a1ae70aa83147488c408f40275ec261f5bb0a6d0", [], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
-  "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [], [], "hexpm"}}
+  "exq": {:hex, :exq, "0.9.0", "3feeb085fcd94a687033211e10c78cf9dca1de062aac3fa9a4b1f808cdcea522", [:mix], [{:poison, ">= 1.2.0 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}, {:redix, ">= 0.5.0", [hex: :redix, repo: "hexpm", optional: false]}, {:uuid, ">= 1.0.0", [hex: :uuid, repo: "hexpm", optional: false]}], "hexpm"},
+  "gen_stage": {:hex, :gen_stage, "0.13.1", "edff5bca9cab22c5d03a834062515e6a1aeeb7665fb44eddae086252e39c4378", [:mix], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.13.3", "c277cfb2a9c5034d445a722494c13359e361d344ef6f25d604c2353185682bfc", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
+  "redix": {:hex, :redix, "0.6.1", "20986b0e02f02b13e6f53c79a1ae70aa83147488c408f40275ec261f5bb0a6d0", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
+  "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], [], "hexpm"},
+}

--- a/lib/ecto_job/config.ex
+++ b/lib/ecto_job/config.ex
@@ -1,0 +1,62 @@
+defmodule EctoJob.Config do
+  @moduledoc """
+  EctoJob Configuration struct.
+
+  Configuration may be provided directly to your JobQueue supervisor:
+
+      supervisor(MyApp.JobQueue, [[repo: MyApp.Repo, max_demand: 100, log_level: :debug]])
+
+  Or if the configuration should be environment-specific, use Mix config:
+
+      config :ecto_job,
+        repo: MyApp.Repo,
+        max_demand: 100,
+        log_level: :debug
+
+  Otherwise default values will be used.
+
+  Configurable values:
+
+    - `repo`: (Required) The `Ecto.Repo` module in your application to use for accessing the `JobQueue`
+    - `max_demand`: (Default `100`) The number of concurrent worker processes to use, see `ConsumerSupervisor` for more details
+    - `log`: (Default `true`) Enables logging using the standard Elixir `Logger` module
+    - `log_level`: (Default `:info`) The level used to log messages, see [Logger](https://hexdocs.pm/logger/Logger.html#module-levels)
+    - `poll_interval`: (Default `60_000`) Time in milliseconds between polling the `JobQueue` for scheduled jobs or jobs due to be retried
+  """
+
+  alias __MODULE__
+
+  defstruct repo: nil,
+            schema: nil,
+            max_demand: 100,
+            log: true,
+            log_level: :info,
+            poll_interval: 60_000
+
+  @type t :: %Config{}
+
+  @doc """
+  Constructs a new `Config` from params, falling back to Application environment then to default values.
+
+  ## Example
+
+      iex> EctoJob.Config.new(repo: MyApp.Repo, log: false)
+      %EctoJob.Config{
+        repo: MyApp.Repo,
+        max_demand: 100,
+        log: false,
+        log_level: :info,
+        poll_interval: 60_000
+      }
+  """
+  @spec new(Keyword.t()) :: Config.t()
+  def new(params \\ []) when is_list(params) do
+    defaults = Map.from_struct(%Config{})
+
+    Enum.reduce(defaults, %Config{}, fn {key, default}, config ->
+      default = Application.get_env(:ecto_job, key, default)
+      value = Keyword.get(params, key, default)
+      Map.put(config, key, value)
+    end)
+  end
+end

--- a/lib/ecto_job/job_queue.ex
+++ b/lib/ecto_job/job_queue.ex
@@ -60,7 +60,8 @@ defmodule EctoJob.JobQueue do
 
       @doc """
       Supervisor child_spec for use with Elixir 1.5+
-      See `start_link` for available options
+
+      See `EctoJob.Config` for available configuration options.
       """
       @spec child_spec(Keyword.t()) :: Supervisor.child_spec()
       def child_spec(opts) do
@@ -73,10 +74,17 @@ defmodule EctoJob.JobQueue do
 
       @doc """
       Start the JobQueue.Supervisor using the current module as the queue schema.
+
+      See `EctoJob.Config` for available configuration options.
+
+      ## Example
+
+          MyApp.JobQueue.start_link(repo: MyApp.Repo, max_demand: 25)
       """
-      @spec start_link(repo: EctoJob.JobQueue.repo(), max_demand: integer) :: {:ok, pid}
-      def start_link(repo: repo, max_demand: max_demand) do
-        EctoJob.Supervisor.start_link(repo: repo, schema: __MODULE__, max_demand: max_demand)
+      @spec start_link(Keyword.t()) :: {:ok, pid}
+      def start_link(opts) do
+        config = EctoJob.Config.new(opts)
+        EctoJob.Supervisor.start_link(%{config | schema: __MODULE__})
       end
 
       @doc """

--- a/lib/ecto_job/supervisor.ex
+++ b/lib/ecto_job/supervisor.ex
@@ -27,17 +27,13 @@ defmodule EctoJob.Supervisor do
   """
 
   import Supervisor.Spec, only: [worker: 2, supervisor: 2]
-  alias EctoJob.{Producer, WorkerSupervisor}
+  alias EctoJob.{Producer, WorkerSupervisor, Config}
 
   @doc """
   Starts an EctoJob queue supervisor
-
-   - `repo`       : Ecto Repo module
-   - `schema`     : EctoJob.JobQueue Module for the schema representing the queue
-   - `max_demand` : Sets the maximum concurrency for job workers
   """
-  @spec start_link(repo: module, schema: module, max_demand: integer) :: {:ok, pid}
-  def start_link(repo: repo, schema: schema, max_demand: max_demand) do
+  @spec start_link(Config.t) :: {:ok, pid}
+  def start_link(%Config{repo: repo, schema: schema, max_demand: max_demand}) do
     supervisor_name = String.to_atom("#{schema}.Supervisor")
     notifier_name = String.to_atom("#{schema}.Notifier")
     producer_name = String.to_atom("#{schema}.Producer")

--- a/lib/ecto_job/supervisor.ex
+++ b/lib/ecto_job/supervisor.ex
@@ -33,7 +33,7 @@ defmodule EctoJob.Supervisor do
   Starts an EctoJob queue supervisor
   """
   @spec start_link(Config.t) :: {:ok, pid}
-  def start_link(%Config{repo: repo, schema: schema, max_demand: max_demand}) do
+  def start_link(config = %Config{repo: repo, schema: schema, max_demand: max_demand, poll_interval: poll_interval}) do
     supervisor_name = String.to_atom("#{schema}.Supervisor")
     notifier_name = String.to_atom("#{schema}.Notifier")
     producer_name = String.to_atom("#{schema}.Producer")
@@ -41,10 +41,10 @@ defmodule EctoJob.Supervisor do
     children = [
       worker(Postgrex.Notifications, [repo.config() ++ [name: notifier_name]]),
       worker(Producer, [
-        [name: producer_name, repo: repo, schema: schema, notifier: notifier_name]
+        [name: producer_name, repo: repo, schema: schema, notifier: notifier_name, poll_interval: poll_interval]
       ]),
       supervisor(WorkerSupervisor, [
-        [repo: repo, subscribe_to: [{producer_name, max_demand: max_demand}]]
+        [config: config, subscribe_to: [{producer_name, max_demand: max_demand}]]
       ])
     ]
 

--- a/lib/ecto_job/worker.ex
+++ b/lib/ecto_job/worker.ex
@@ -2,41 +2,39 @@ defmodule EctoJob.Worker do
   @moduledoc """
   Worker module responsible for executing a single Job
   """
-  alias EctoJob.JobQueue
+  alias EctoJob.{Config, JobQueue}
   require Logger
 
   @type repo :: module
 
   @doc """
-  Equivalent to `start_link(repo, job, DateTime.utc_now())`
+  Equivalent to `start_link(config, job, DateTime.utc_now())`
   """
-  @spec start_link(repo, EctoJob.JobQueue.job()) :: {:ok, pid}
-  def start_link(repo, job), do: start_link(repo, job, DateTime.utc_now())
+  @spec start_link(Config.t, EctoJob.JobQueue.job()) :: {:ok, pid}
+  def start_link(config, job), do: start_link(config, job, DateTime.utc_now())
 
   @doc """
   Start a worker process given a repo module and a job struct
   This may fail if the job reservation has expired, in which case the job will be
   reactivated by the producer.
   """
-  @spec start_link(repo, EctoJob.JobQueue.job(), DateTime.t()) :: {:ok, pid}
-  def start_link(repo, job = %queue{}, now) do
+  @spec start_link(Config.t, EctoJob.JobQueue.job(), DateTime.t()) :: {:ok, pid}
+  def start_link(config = %Config{repo: repo}, job = %queue{}, now) do
     Task.start_link(fn ->
       with {:ok, job} <- JobQueue.update_job_in_progress(repo, job, now) do
         queue.perform(JobQueue.initial_multi(job), job.params)
-        log_duration(job, now)
+        log_duration(config, job, now)
         notify_completed(repo, job)
       end
     end)
   end
 
-  @spec log_duration(EctoJob.JobQueue.job(), DateTime.t()) :: :ok
-  defp log_duration(_job = %queue{id: id}, start = %DateTime{}) do
+  @spec log_duration(Config.t, EctoJob.JobQueue.job(), DateTime.t()) :: :ok
+  defp log_duration(%Config{log: true, log_level: log_level}, _job = %queue{id: id}, start = %DateTime{}) do
     duration = DateTime.diff(DateTime.utc_now(), start, :microseconds)
-    if Application.get_env(:ecto_job, :log, true) do
-      level = Application.get_env(:ecto_job, :log_level, :info)
-      Logger.log(level, fn -> "#{queue}[#{id}] done: #{duration} µs" end)
-    end
+    Logger.log(log_level, fn -> "#{queue}[#{id}] done: #{duration} µs" end)
   end
+  defp log_duration(_config, _job, _start), do: :ok
 
   @spec notify_completed(repo, EctoJob.JobQueue.job()) :: :ok
   defp notify_completed(_repo, _job = %{notify: nil}), do: :ok

--- a/lib/ecto_job/worker_supervisor.ex
+++ b/lib/ecto_job/worker_supervisor.ex
@@ -4,18 +4,18 @@ defmodule EctoJob.WorkerSupervisor do
   """
 
   import Supervisor.Spec
-  alias EctoJob.Worker
+  alias EctoJob.{Config, Worker}
 
   @doc """
   Starts the ConsumerSupervisor
 
-   - `repo` : The Ecto.Repo module
+   - `config` : The JobQueue configuration, used for Repo, Logging options
    - `subscribe_opts` : Should contain [{producer_name, max_demand: max_demand}]
   """
-  @spec start_link(repo: module, subscribe_to: Keyword.t()) :: Supervisor.on_start()
-  def start_link(repo: repo, subscribe_to: subscribe_opts) do
+  @spec start_link(config: Config.t, subscribe_to: Keyword.t()) :: Supervisor.on_start()
+  def start_link(config: config, subscribe_to: subscribe_opts) do
     children = [
-      worker(Worker, [repo], restart: :temporary)
+      worker(Worker, [config], restart: :temporary)
     ]
 
     ConsumerSupervisor.start_link(children, strategy: :one_for_one, subscribe_to: subscribe_opts)

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule EctoJob.Mixfile do
   defp docs do
     [
       extras: ["README.md"],
+      main: "readme",
       source_ref: "v#{@version}",
       source_url: @url,
       homepage_url: @url

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule EctoJob.Mixfile do
       version: @version,
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
+      elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: dialyzer(),

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -1,0 +1,4 @@
+defmodule EctoJob.ConfigTest do
+  use ExUnit.Case
+  doctest EctoJob.Config
+end

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -12,7 +12,8 @@ defmodule EctoJob.ProducerTest do
         schema: JobQueue,
         notifier: nil,
         demand: 0,
-        clock: fn -> DateTime.from_naive!(~N[2017-08-17T12:24:00Z], "Etc/UTC") end
+        clock: fn -> DateTime.from_naive!(~N[2017-08-17T12:24:00Z], "Etc/UTC") end,
+        poll_interval: 60_000
       }
     }
   end


### PR DESCRIPTION
Fixes #10 

This PR introduces `EctoJob.Config`. A struct which contains the configuration for a `JobQueue`.
It is initialised from  3 sources:

1. Params passed directly to the childspec: `supervisor(MyJobQueue, [[repo: MyApp.Repo, max_demand: 100, log_level: :debug]])`
2. In the application config: `config :ecto_job, log: false, poll_interval: 15_000`
3. With default values in the code.

