### PR TITLE
Make base expiry configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ You can customize how often the table is polled for scheduled jobs.  The default
 config :ecto_job, :poll_interval, 15_000
 ```
 
+Control both the time period the job is reserved by a waiting worker before it's started and the base retry interval for failed/timed out jobs. Keep in mind, for jobs that are expected to retry quickly, any configured `base_expiry_seconds` will only retry a job as quickly as the `poll_interval`. An exception to this may be the first retry, which may not be bounded similarly if the initial job trigger dispatches the first attempt mid-interval.
+
+```
+config :ecto_job, :base_expiry_seconds, 60
+```
+
 You can control whether logs are on or off and the log level.  The default is `true` and `:info`.
 
 ```

--- a/lib/ecto_job/config.ex
+++ b/lib/ecto_job/config.ex
@@ -22,7 +22,8 @@ defmodule EctoJob.Config do
     - `log`: (Default `true`) Enables logging using the standard Elixir `Logger` module
     - `log_level`: (Default `:info`) The level used to log messages, see [Logger](https://hexdocs.pm/logger/Logger.html#module-levels)
     - `poll_interval`: (Default `60_000`) Time in milliseconds between polling the `JobQueue` for scheduled jobs or jobs due to be retried
-    - `base_expiry_seconds`: (Default `300`) Time in seconds where a `RESERVED` or `IN_PROGRESS` job state is held before subsequent polls return a job to the `AVAILABLE` state for retry. The time will double for every retry until `max_attemps` is reached for a given job.
+    - `reservation_timeout`: (Default `60_000`) Time in ms during which a `RESERVED` job state is held while waiting for a worker to start the job. Subsequent polls will return the job to the `AVAILABLE` state for retry.
+    - `execution_timeout`: (Default `300_000`) Time in ms that a worker is allotted to hold a job in the `IN_PROGRESS` state before subsequent polls return a job to the `AVAILABLE` state for retry. The timeout is extended by `execution_timeout` for every retry attempt until `max_attemps` is reached for a given job.
   """
 
   alias __MODULE__
@@ -33,7 +34,8 @@ defmodule EctoJob.Config do
             log: true,
             log_level: :info,
             poll_interval: 60_000,
-            base_expiry_seconds: 300
+            reservation_timeout: 60_000,
+            execution_timeout: 300_000
 
   @type t :: %Config{}
 
@@ -49,7 +51,8 @@ defmodule EctoJob.Config do
         log: false,
         log_level: :info,
         poll_interval: 60_000,
-        base_expiry_seconds: 300
+        reservation_timeout: 60_000,
+        execution_timeout: 300_000
       }
   """
   @spec new(Keyword.t()) :: Config.t()

--- a/lib/ecto_job/config.ex
+++ b/lib/ecto_job/config.ex
@@ -22,6 +22,7 @@ defmodule EctoJob.Config do
     - `log`: (Default `true`) Enables logging using the standard Elixir `Logger` module
     - `log_level`: (Default `:info`) The level used to log messages, see [Logger](https://hexdocs.pm/logger/Logger.html#module-levels)
     - `poll_interval`: (Default `60_000`) Time in milliseconds between polling the `JobQueue` for scheduled jobs or jobs due to be retried
+    - `base_expiry_seconds`: (Default `300`) Time in seconds where a `RESERVED` or `IN_PROGRESS` job state is held before subsequent polls return a job to the `AVAILABLE` state for retry. The time will double for every retry until `max_attemps` is reached for a given job.
   """
 
   alias __MODULE__
@@ -31,7 +32,8 @@ defmodule EctoJob.Config do
             max_demand: 100,
             log: true,
             log_level: :info,
-            poll_interval: 60_000
+            poll_interval: 60_000,
+            base_expiry_seconds: 300
 
   @type t :: %Config{}
 
@@ -46,7 +48,8 @@ defmodule EctoJob.Config do
         max_demand: 100,
         log: false,
         log_level: :info,
-        poll_interval: 60_000
+        poll_interval: 60_000,
+        base_expiry_seconds: 300
       }
   """
   @spec new(Keyword.t()) :: Config.t()

--- a/lib/ecto_job/supervisor.ex
+++ b/lib/ecto_job/supervisor.ex
@@ -33,7 +33,7 @@ defmodule EctoJob.Supervisor do
   Starts an EctoJob queue supervisor
   """
   @spec start_link(Config.t) :: {:ok, pid}
-  def start_link(config = %Config{repo: repo, schema: schema, max_demand: max_demand, poll_interval: poll_interval, base_expiry_seconds: base_expiry_seconds}) do
+  def start_link(config = %Config{repo: repo, schema: schema, max_demand: max_demand, poll_interval: poll_interval, reservation_timeout: reservation_timeout, execution_timeout: execution_timeout}) do
     supervisor_name = String.to_atom("#{schema}.Supervisor")
     notifier_name = String.to_atom("#{schema}.Notifier")
     producer_name = String.to_atom("#{schema}.Producer")
@@ -41,7 +41,7 @@ defmodule EctoJob.Supervisor do
     children = [
       worker(Postgrex.Notifications, [repo.config() ++ [name: notifier_name]]),
       worker(Producer, [
-        [name: producer_name, repo: repo, schema: schema, notifier: notifier_name, poll_interval: poll_interval, base_expiry_seconds: base_expiry_seconds]
+        [name: producer_name, repo: repo, schema: schema, notifier: notifier_name, poll_interval: poll_interval, reservation_timeout: reservation_timeout, execution_timeout: execution_timeout]
       ]),
       supervisor(WorkerSupervisor, [
         [config: config, subscribe_to: [{producer_name, max_demand: max_demand}]]

--- a/lib/ecto_job/supervisor.ex
+++ b/lib/ecto_job/supervisor.ex
@@ -33,7 +33,7 @@ defmodule EctoJob.Supervisor do
   Starts an EctoJob queue supervisor
   """
   @spec start_link(Config.t) :: {:ok, pid}
-  def start_link(config = %Config{repo: repo, schema: schema, max_demand: max_demand, poll_interval: poll_interval}) do
+  def start_link(config = %Config{repo: repo, schema: schema, max_demand: max_demand, poll_interval: poll_interval, base_expiry_seconds: base_expiry_seconds}) do
     supervisor_name = String.to_atom("#{schema}.Supervisor")
     notifier_name = String.to_atom("#{schema}.Notifier")
     producer_name = String.to_atom("#{schema}.Producer")
@@ -41,7 +41,7 @@ defmodule EctoJob.Supervisor do
     children = [
       worker(Postgrex.Notifications, [repo.config() ++ [name: notifier_name]]),
       worker(Producer, [
-        [name: producer_name, repo: repo, schema: schema, notifier: notifier_name, poll_interval: poll_interval]
+        [name: producer_name, repo: repo, schema: schema, notifier: notifier_name, poll_interval: poll_interval, base_expiry_seconds: base_expiry_seconds]
       ]),
       supervisor(WorkerSupervisor, [
         [config: config, subscribe_to: [{producer_name, max_demand: max_demand}]]

--- a/lib/ecto_job/worker.ex
+++ b/lib/ecto_job/worker.ex
@@ -19,9 +19,9 @@ defmodule EctoJob.Worker do
   reactivated by the producer.
   """
   @spec start_link(Config.t, EctoJob.JobQueue.job(), DateTime.t()) :: {:ok, pid}
-  def start_link(config = %Config{repo: repo, base_expiry_seconds: base_expiry}, job = %queue{}, now) do
+  def start_link(config = %Config{repo: repo, execution_timeout: timeout}, job = %queue{}, now) do
     Task.start_link(fn ->
-      with {:ok, job} <- JobQueue.update_job_in_progress(repo, job, now, base_expiry) do
+      with {:ok, job} <- JobQueue.update_job_in_progress(repo, job, now, timeout) do
         queue.perform(JobQueue.initial_multi(job), job.params)
         log_duration(config, job, now)
         notify_completed(repo, job)

--- a/lib/ecto_job/worker.ex
+++ b/lib/ecto_job/worker.ex
@@ -19,9 +19,9 @@ defmodule EctoJob.Worker do
   reactivated by the producer.
   """
   @spec start_link(Config.t, EctoJob.JobQueue.job(), DateTime.t()) :: {:ok, pid}
-  def start_link(config = %Config{repo: repo}, job = %queue{}, now) do
+  def start_link(config = %Config{repo: repo, base_expiry_seconds: base_expiry}, job = %queue{}, now) do
     Task.start_link(fn ->
-      with {:ok, job} <- JobQueue.update_job_in_progress(repo, job, now) do
+      with {:ok, job} <- JobQueue.update_job_in_progress(repo, job, now, base_expiry) do
         queue.perform(JobQueue.initial_multi(job), job.params)
         log_duration(config, job, now)
         notify_completed(repo, job)

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -13,7 +13,8 @@ defmodule EctoJob.ProducerTest do
         notifier: nil,
         demand: 0,
         clock: fn -> DateTime.from_naive!(~N[2017-08-17T12:24:00Z], "Etc/UTC") end,
-        poll_interval: 60_000
+        poll_interval: 60_000,
+        base_expiry_seconds: 300,
       }
     }
   end

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -14,7 +14,8 @@ defmodule EctoJob.ProducerTest do
         demand: 0,
         clock: fn -> DateTime.from_naive!(~N[2017-08-17T12:24:00Z], "Etc/UTC") end,
         poll_interval: 60_000,
-        base_expiry_seconds: 300,
+        reservation_timeout: 60_000,
+        execution_timeout: 300_000,
       }
     }
   end


### PR DESCRIPTION
Here's a first pass at making the expiry configurable as I was asking in #17. Let me know if you think this works. I added a bit more to the README as well about how you might shoot yourself in the foot with a shorter expiry.

One small uncertainty I had while working on this was wondering if there is any reason for the RESERVED expiry to be different from the IN_PROGRESS attempt-1 expiry. The RESERVED expiry seems like it would rare, at least running on a single node. Could you see a reason that this maybe remain a 5-minute constant, where the IN_PROGRESS should be configurable. Or should they be configurable separately?