### PR TITLE
feat: Add ALWAYS_DISPATCH_JOBS_ON_POLL processing option

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,4 +19,6 @@ if Mix.env() == :test do
 
   config :logger, level: :warn
 
+  config :ecto_job,
+    always_dispatch_jobs_on_poll: System.get_env("ALWAYS_DISPATCH_JOBS_ON_POLL") || "false"
 end

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -15,7 +15,7 @@ defmodule EctoJob.ProducerTest do
         clock: fn -> DateTime.from_naive!(~N[2017-08-17T12:24:00Z], "Etc/UTC") end,
         poll_interval: 60_000,
         reservation_timeout: 60_000,
-        execution_timeout: 300_000,
+        execution_timeout: 300_000
       }
     }
   end
@@ -32,6 +32,23 @@ defmodule EctoJob.ProducerTest do
 
       assert {:noreply, [%JobQueue{}], %{demand: 9}} =
                Producer.handle_info(:poll, %{state | demand: 10})
+    end
+
+    test "When always_dispatch_jobs_on_poll is true", %{state: state} do
+      Application.put_env(:ecto_job, :always_dispatch_jobs_on_poll, "true")
+
+      Repo.insert!(JobQueue.new(%{}))
+
+      assert {:noreply, [%JobQueue{}], %{demand: 9}} =
+               Producer.handle_info(:poll, %{state | demand: 10})
+    end
+
+    test "When always_dispatch_jobs_on_poll is false", %{state: state} do
+      Application.put_env(:ecto_job, :always_dispatch_jobs_on_poll, "false")
+
+      Repo.insert!(JobQueue.new(%{}))
+
+      assert {:noreply, [], %{demand: 10}} = Producer.handle_info(:poll, %{state | demand: 10})
     end
   end
 


### PR DESCRIPTION
Altera o formato de pooling da biblioteca para pegar todos os jobs disponíveis para processamento.

Essa opção é configurável pela flag ALWAYS_DISPATCH_JOBS_ON_POLL.

O comportamento default é o original, onde são processados no pool apenas agendamentos expirados e agendados (com data já alcançada).