### PR TITLE
feat: Add :always_dispatch_jobs_on_poll option

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,5 +18,4 @@ if Mix.env() == :test do
   config :ecto_job, ecto_repos: [EctoJob.Test.Repo]
 
   config :logger, level: :warn
-
 end

--- a/lib/ecto_job/config.ex
+++ b/lib/ecto_job/config.ex
@@ -24,6 +24,7 @@ defmodule EctoJob.Config do
     - `poll_interval`: (Default `60_000`) Time in milliseconds between polling the `JobQueue` for scheduled jobs or jobs due to be retried
     - `reservation_timeout`: (Default `60_000`) Time in ms during which a `RESERVED` job state is held while waiting for a worker to start the job. Subsequent polls will return the job to the `AVAILABLE` state for retry.
     - `execution_timeout`: (Default `300_000`) Time in ms that a worker is allotted to hold a job in the `IN_PROGRESS` state before subsequent polls return a job to the `AVAILABLE` state for retry. The timeout is extended by `execution_timeout` for every retry attempt until `max_attemps` is reached for a given job.
+    - `always_dispatch_jobs_on_poll`: (Default `false`)
   """
 
   alias __MODULE__
@@ -35,7 +36,8 @@ defmodule EctoJob.Config do
             log_level: :info,
             poll_interval: 60_000,
             reservation_timeout: 60_000,
-            execution_timeout: 300_000
+            execution_timeout: 300_000,
+            always_dispatch_jobs_on_poll: false
 
   @type t :: %Config{}
 
@@ -52,7 +54,8 @@ defmodule EctoJob.Config do
         log_level: :info,
         poll_interval: 60_000,
         reservation_timeout: 60_000,
-        execution_timeout: 300_000
+        execution_timeout: 300_000,
+        always_dispatch_jobs_on_poll: false
       }
   """
   @spec new(Keyword.t()) :: Config.t()

--- a/lib/ecto_job/supervisor.ex
+++ b/lib/ecto_job/supervisor.ex
@@ -32,8 +32,18 @@ defmodule EctoJob.Supervisor do
   @doc """
   Starts an EctoJob queue supervisor
   """
-  @spec start_link(Config.t) :: {:ok, pid}
-  def start_link(config = %Config{repo: repo, schema: schema, max_demand: max_demand, poll_interval: poll_interval, reservation_timeout: reservation_timeout, execution_timeout: execution_timeout}) do
+  @spec start_link(Config.t()) :: {:ok, pid}
+  def start_link(
+        config = %Config{
+          repo: repo,
+          schema: schema,
+          max_demand: max_demand,
+          poll_interval: poll_interval,
+          reservation_timeout: reservation_timeout,
+          execution_timeout: execution_timeout,
+          always_dispatch_jobs_on_poll: always_dispatch_jobs_on_poll
+        }
+      ) do
     supervisor_name = String.to_atom("#{schema}.Supervisor")
     notifier_name = String.to_atom("#{schema}.Notifier")
     producer_name = String.to_atom("#{schema}.Producer")
@@ -41,7 +51,16 @@ defmodule EctoJob.Supervisor do
     children = [
       worker(Postgrex.Notifications, [repo.config() ++ [name: notifier_name]]),
       worker(Producer, [
-        [name: producer_name, repo: repo, schema: schema, notifier: notifier_name, poll_interval: poll_interval, reservation_timeout: reservation_timeout, execution_timeout: execution_timeout]
+        [
+          name: producer_name,
+          repo: repo,
+          schema: schema,
+          notifier: notifier_name,
+          poll_interval: poll_interval,
+          reservation_timeout: reservation_timeout,
+          execution_timeout: execution_timeout,
+          always_dispatch_jobs_on_poll: always_dispatch_jobs_on_poll
+        ]
       ]),
       supervisor(WorkerSupervisor, [
         [config: config, subscribe_to: [{producer_name, max_demand: max_demand}]]

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -16,6 +16,7 @@ defmodule EctoJob.ProducerTest do
         poll_interval: 60_000,
         reservation_timeout: 60_000,
         execution_timeout: 300_000,
+        always_dispatch_jobs_on_poll: false
       }
     }
   end
@@ -32,6 +33,28 @@ defmodule EctoJob.ProducerTest do
 
       assert {:noreply, [%JobQueue{}], %{demand: 9}} =
                Producer.handle_info(:poll, %{state | demand: 10})
+    end
+
+    test "When always_dispatch_jobs_on_poll is true", %{state: state} do
+      Repo.insert!(JobQueue.new(%{}))
+
+      assert {:noreply, [%JobQueue{}], %{demand: 9}} =
+               Producer.handle_info(:poll, %{
+                 state
+                 | demand: 10,
+                   always_dispatch_jobs_on_poll: true
+               })
+    end
+
+    test "When always_dispatch_jobs_on_poll is false", %{state: state} do
+      Repo.insert!(JobQueue.new(%{}))
+
+      assert {:noreply, [], %{demand: 10}} =
+               Producer.handle_info(:poll, %{
+                 state
+                 | demand: 10,
+                   always_dispatch_jobs_on_poll: false
+               })
     end
   end
 


### PR DESCRIPTION
## Overview

This PR adds an option for always polling for jobs on the poll cycle (not only expired and scheduled, but available as well). The point is to not rely only on `LISTEN/NOTIFY` because that can be problematic in a lot of scenarios.

## More Info

@bamorim already talked to @mbuhot a while ago in the Elixir Slack, but we failed to create this PR. Sorry ¯\_(ツ)_/¯

There is a problem with relying only on Postgres' `LISTEN/NOTIFY`. In some scenarios the connection could drop and the connection may not detect it. It could be because of some firewall or because of some proxy. The [problem with `LISTEN/NOTIFY` is present on the Microsoft Azure's Postgres](https://github.com/elixir-ecto/postgrex/issues/375) and we also had the same problem when using Google Cloud SQL Proxy.

Even though the issue was closed, I can confirm it still happens (mostly fault of the Azure).

The point is that even though the problem is not related to this library, depending on this may turn this library a no-go for many people (including us).

That is why this PR is here.

That way, if the connection that postgrex is `LISTENING` have some problem it will only delay the job execution but it wont turn the application useless.