### PR TITLE
Feature Add :notifications_listen_timeout option

### DIFF
--- a/lib/ecto_job/config.ex
+++ b/lib/ecto_job/config.ex
@@ -24,6 +24,7 @@ defmodule EctoJob.Config do
     - `poll_interval`: (Default `60_000`) Time in milliseconds between polling the `JobQueue` for scheduled jobs or jobs due to be retried
     - `reservation_timeout`: (Default `60_000`) Time in ms during which a `RESERVED` job state is held while waiting for a worker to start the job. Subsequent polls will return the job to the `AVAILABLE` state for retry.
     - `execution_timeout`: (Default `300_000`) Time in ms that a worker is allotted to hold a job in the `IN_PROGRESS` state before subsequent polls return a job to the `AVAILABLE` state for retry. The timeout is extended by `execution_timeout` for every retry attempt until `max_attemps` is reached for a given job.
+    - `notifications_listen_timeout`: (Default `5_000`) Time in milliseconds that Notifications.listen!/3 is alloted to start listening to notifications from postgrex for new jobs
   """
 
   alias __MODULE__
@@ -35,7 +36,8 @@ defmodule EctoJob.Config do
             log_level: :info,
             poll_interval: 60_000,
             reservation_timeout: 60_000,
-            execution_timeout: 300_000
+            execution_timeout: 300_000,
+            notifications_listen_timeout: 5_000
 
   @type t :: %Config{}
 
@@ -52,7 +54,8 @@ defmodule EctoJob.Config do
         log_level: :info,
         poll_interval: 60_000,
         reservation_timeout: 60_000,
-        execution_timeout: 300_000
+        execution_timeout: 300_000,
+        notifications_listen_timeout: 5_000
       }
   """
   @spec new(Keyword.t()) :: Config.t()

--- a/lib/ecto_job/supervisor.ex
+++ b/lib/ecto_job/supervisor.ex
@@ -32,8 +32,18 @@ defmodule EctoJob.Supervisor do
   @doc """
   Starts an EctoJob queue supervisor
   """
-  @spec start_link(Config.t) :: {:ok, pid}
-  def start_link(config = %Config{repo: repo, schema: schema, max_demand: max_demand, poll_interval: poll_interval, reservation_timeout: reservation_timeout, execution_timeout: execution_timeout}) do
+  @spec start_link(Config.t()) :: {:ok, pid}
+  def start_link(
+        config = %Config{
+          repo: repo,
+          schema: schema,
+          max_demand: max_demand,
+          poll_interval: poll_interval,
+          reservation_timeout: reservation_timeout,
+          execution_timeout: execution_timeout,
+          notifications_listen_timeout: notifications_listen_timeout
+        }
+      ) do
     supervisor_name = String.to_atom("#{schema}.Supervisor")
     notifier_name = String.to_atom("#{schema}.Notifier")
     producer_name = String.to_atom("#{schema}.Producer")
@@ -41,7 +51,16 @@ defmodule EctoJob.Supervisor do
     children = [
       worker(Postgrex.Notifications, [repo.config() ++ [name: notifier_name]]),
       worker(Producer, [
-        [name: producer_name, repo: repo, schema: schema, notifier: notifier_name, poll_interval: poll_interval, reservation_timeout: reservation_timeout, execution_timeout: execution_timeout]
+        [
+          name: producer_name,
+          repo: repo,
+          schema: schema,
+          notifier: notifier_name,
+          poll_interval: poll_interval,
+          reservation_timeout: reservation_timeout,
+          execution_timeout: execution_timeout,
+          notifications_listen_timeout: notifications_listen_timeout
+        ]
       ]),
       supervisor(WorkerSupervisor, [
         [config: config, subscribe_to: [{producer_name, max_demand: max_demand}]]

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -16,6 +16,7 @@ defmodule EctoJob.ProducerTest do
         poll_interval: 60_000,
         reservation_timeout: 60_000,
         execution_timeout: 300_000,
+        notifications_listen_timeout: 5_000
       }
     }
   end


### PR DESCRIPTION
Hi, thanks for the great work on that library !

I wanted to add a feature that allows to set up a custom timeout on the postgrex notification listener
to start up.

The default value is 5000ms which is the default value in `Postgrex.Notification`
module.