### PR TITLE
Dispatch available jobs when polling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: elixir
 
 elixir:
-  - 1.5.3
   - 1.6.6
   - 1.7.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: elixir
 
 elixir:
   - 1.5.3
-  - 1.6.4
+  - 1.6.6
+  - 1.7.3
 
 otp_release:
   - 20.3
+  - 21.1
 
 addons:
   postgresql: "9.6"

--- a/lib/ecto_job/job_queue.ex
+++ b/lib/ecto_job/job_queue.ex
@@ -277,7 +277,8 @@ defmodule EctoJob.JobQueue do
 
   Returns `{:ok, job}` when sucessful, `{:error, :expired}` otherwise.
   """
-  @spec update_job_in_progress(repo, job, DateTime.t(), integer) :: {:ok, job} | {:error, :expired}
+  @spec update_job_in_progress(repo, job, DateTime.t(), integer) ::
+          {:ok, job} | {:error, :expired}
   def update_job_in_progress(repo, job = %schema{}, now, timeout_ms) do
     {count, results} =
       repo.update_all(

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule EctoJob.Mixfile do
       app: :ecto_job,
       description: "A transactional job queue built with Ecto, PostgreSQL and GenStage.",
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env() == :prod,

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -27,6 +27,13 @@ defmodule EctoJob.ProducerTest do
       assert {:noreply, [], ^state} = Producer.handle_info(:poll, state)
     end
 
+    test "When pending demand and available jobs", %{state: state} do
+      Repo.insert!(JobQueue.new(%{}))
+
+      assert {:noreply, [%JobQueue{}], %{demand: 9}} =
+               Producer.handle_info(:poll, %{state | demand: 10})
+    end
+
     test "When scheduled jobs can be activated", %{state: state} do
       at = DateTime.from_naive!(~N[2017-08-17T12:23:34.0Z], "Etc/UTC")
       Repo.insert!(JobQueue.new(%{}, schedule: at))


### PR DESCRIPTION
This is primarily to support EctoJob in Azure where pg_notify is known to not work.
https://github.com/elixir-ecto/postgrex/issues/375

Additionally, this change ensures that even if there is no demand,
poll messages still activate scheduled / expired jobs.

