### PR TITLE
Explicitly declare a bigserial primary key on Jobs tables

### DIFF
--- a/lib/ecto_job/migrations.ex
+++ b/lib/ecto_job/migrations.ex
@@ -44,9 +44,10 @@ defmodule EctoJob.Migrations do
     @moduledoc """
     Adds a job queue table with the given name, and attaches an insert trigger.
     """
-    def up(name) do
+    def up(name, _opts \\ []) do
       _ =
-        create table(name) do
+        create table(name, primary_key: false) do
+          add(:id, :bigserial, primary_key: true)
           add(:state, :string, null: false, default: "AVAILABLE")
           add(:expires, :utc_datetime_usec)
 


### PR DESCRIPTION
Fixes #18

Prior to this change, the primary key type would be affected by the value of the `:migration_primary_key` configuration.

Now it explicitly always uses `:bigserial` for the primary key.
