### PR TITLE
Allow customizing timestamp fields

### DIFF
--- a/lib/ecto_job/job_queue.ex
+++ b/lib/ecto_job/job_queue.ex
@@ -6,6 +6,7 @@ defmodule EctoJob.JobQueue do
 
   * `:table_name` - (_required_) The name of the job table in the database.
   * `:schema_prefix` - (_optional_) The schema prefix for the table.
+  * `:timestamps_opts` - (_optional_) Configures the timestamp fields for the schema (See `Ecto.Schema.timestamps/1`)
 
   ## Example
 
@@ -70,15 +71,25 @@ defmodule EctoJob.JobQueue do
   defmacro __using__(opts) do
     table_name = Keyword.fetch!(opts, :table_name)
     schema_prefix = Keyword.get(opts, :schema_prefix)
+    timestamps_opts = Keyword.get(opts, :timestamps_opts)
 
-    quote do
+    quote bind_quoted: [
+            table_name: table_name,
+            schema_prefix: schema_prefix,
+            timestamps_opts: timestamps_opts
+          ] do
       use Ecto.Schema
       @behaviour EctoJob.JobQueue
-      if unquote(schema_prefix) do
-        @schema_prefix unquote(schema_prefix)
+
+      if schema_prefix do
+        @schema_prefix schema_prefix
       end
 
-      schema unquote(table_name) do
+      if timestamps_opts do
+        @timestamps_opts timestamps_opts
+      end
+
+      schema table_name do
         # SCHEDULED, RESERVED, IN_PROGRESS, FAILED
         field(:state, :string)
         # Time at which reserved/in_progress jobs can be reset to SCHEDULED

--- a/lib/ecto_job/migrations.ex
+++ b/lib/ecto_job/migrations.ex
@@ -65,10 +65,12 @@ defmodule EctoJob.Migrations do
     ## Options
 
     * `:prefix` - the prefix (aka Postgresql schema) to create the table in.
+    * `:timestamps` - A keyword list of options passed to the `Ecto.Migration.timestamps/1` function.
     """
     def up(name, opts \\ []) do
       opts = [{:primary_key, false} | opts]
       prefix = Keyword.get(opts, :prefix)
+      timestamp_opts = Keyword.get(opts, :timestamps, [])
 
       _ =
         create table(name, opts) do
@@ -85,7 +87,7 @@ defmodule EctoJob.Migrations do
           add(:max_attempts, :integer, null: false, default: 5)
           add(:params, :map, null: false)
           add(:notify, :string)
-          timestamps()
+          timestamps(timestamp_opts)
         end
 
       execute("""


### PR DESCRIPTION
Adds options for customizing timestamps in migrations and JobQueue schemas.

Related to #19 