### PR TITLE
Improve local test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+compose:
+	docker-compose -f docker-compose-test.yml up -d
+
+db_setup:
+	MIX_ENV=test mix do ecto.create, ecto.migrate
+
+test: compose db_setup
+	mix test

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+  ecto-job-test:
+    image: postgres:9.6-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=ecto_job_test


### PR DESCRIPTION
By:
* bootstrapping test postgres instance with `docker-compose`
* bundling all required steps to execute tests locally under single: `make test` command