### PR TITLE
Add api to requeue a failed job

### DIFF
--- a/lib/ecto_job/job_queue.ex
+++ b/lib/ecto_job/job_queue.ex
@@ -189,7 +189,7 @@ defmodule EctoJob.JobQueue do
           |> MyApp.Job.requeue("requeue_job", failed_job)
           |> MyApp.Repo.transaction()
       """
-      @spec requeue(Multi.t(), term, EctoJob.JobQueue.job()) :: Multi.t()
+      @spec requeue(Multi.t(), term, EctoJob.JobQueue.job()) :: Multi.t() | {:error, :non_failed_job}
       def requeue(multi, name, job = %__MODULE__{state: "FAILED"}) do
           job_to_requeue = Changeset.change(job, %{state: "SCHEDULED", attempt: 0, expires: nil})
           Multi.update(multi, name, job_to_requeue)


### PR DESCRIPTION
I believe it is quite common scenario, that after job has failed (even after retries),
we want to re-queue it (manually, via some sort of admin functionality), so the job
finally does what it was supposed to do.