### PR TITLE
Add RETRYING state to state machine

### DIFF
--- a/lib/ecto_job/config.ex
+++ b/lib/ecto_job/config.ex
@@ -24,6 +24,7 @@ defmodule EctoJob.Config do
     - `poll_interval`: (Default `60_000`) Time in milliseconds between polling the `JobQueue` for scheduled jobs or jobs due to be retried
     - `reservation_timeout`: (Default `60_000`) Time in ms during which a `RESERVED` job state is held while waiting for a worker to start the job. Subsequent polls will return the job to the `AVAILABLE` state for retry.
     - `execution_timeout`: (Default `300_000`) Time in ms that a worker is allotted to hold a job in the `IN_PROGRESS` state before subsequent polls return a job to the `AVAILABLE` state for retry. The timeout is extended by `execution_timeout` for every retry attempt until `max_attemps` is reached for a given job.
+    - `retrying_timeout`: (Default `300_000`) Time in ms that a worker is allotted to hold a job in the `RETRYING` state before subsequent polls return a job to the `AVAILABLE` state for retry.
     - `notifications_listen_timeout`: (Default `5_000`) Time in milliseconds that Notifications.listen!/3 is alloted to start listening to notifications from postgrex for new jobs
   """
 
@@ -36,6 +37,7 @@ defmodule EctoJob.Config do
             log_level: :info,
             poll_interval: 60_000,
             reservation_timeout: 60_000,
+            retrying_timeout: 300_000,
             execution_timeout: 300_000,
             notifications_listen_timeout: 5_000
 
@@ -54,6 +56,7 @@ defmodule EctoJob.Config do
         log_level: :info,
         poll_interval: 60_000,
         reservation_timeout: 60_000,
+        retrying_timeout: 300_000,
         execution_timeout: 300_000,
         notifications_listen_timeout: 5_000
       }

--- a/lib/ecto_job/job_queue.ex
+++ b/lib/ecto_job/job_queue.ex
@@ -30,6 +30,7 @@ defmodule EctoJob.JobQueue do
    - `"AVAILABLE"`: The job is availble to be run by the next available worker
    - `"RESERVED"`: The job has been reserved by a worker for execution
    - `"IN_PROGRESS"`: The job is currently being worked
+   - `"RETRYING"`: The job has failed and it's waiting for a retry
    - `"FAILED"`: The job has exceeded the `max_attempts` and will not be retried again
   """
   @type state :: String.t()
@@ -157,7 +158,7 @@ defmodule EctoJob.JobQueue do
   end
 
   @doc """
-  Updates all jobs in the `"SCHEDULED"` state with scheduled time <= now to `"AVAILABLE"` state.
+  Updates all jobs in the `"SCHEDULED"` and `"RETRYING"` state with scheduled time <= now to `"AVAILABLE"` state.
 
   Returns the number of jobs updated.
   """
@@ -167,7 +168,7 @@ defmodule EctoJob.JobQueue do
       repo.update_all(
         Query.from(
           job in schema,
-          where: job.state == "SCHEDULED",
+          where: job.state in ["SCHEDULED", "RETRYING"],
           where: job.schedule <= ^now
         ),
         set: [state: "AVAILABLE", updated_at: now]
@@ -211,6 +212,26 @@ defmodule EctoJob.JobQueue do
           where: job.state in ["IN_PROGRESS"],
           where: job.attempt >= job.max_attempts,
           where: job.expires < ^now
+        ),
+        set: [state: "FAILED", expires: nil, updated_at: now]
+      )
+
+    count
+  end
+
+  @doc """
+  Updates all RETRYING jobs that have been attempted the maximum number of times to `"FAILED"`.
+
+  Returns the number of jobs updated.
+  """
+  @spec fail_retrying_jobs_at_max_attempts(repo, schema, DateTime.t()) :: integer
+  def fail_retrying_jobs_at_max_attempts(repo, schema, now = %DateTime{}) do
+    {count, _} =
+      repo.update_all(
+        Query.from(
+          job in schema,
+          where: job.state in ["RETRYING"],
+          where: job.attempt >= job.max_attempts
         ),
         set: [state: "FAILED", expires: nil, updated_at: now]
       )
@@ -292,7 +313,7 @@ defmodule EctoJob.JobQueue do
         set: [
           attempt: job.attempt + 1,
           state: "IN_PROGRESS",
-          expires: progress_expiry(now, job.attempt + 1, timeout_ms),
+          expires: increase_time(now, job.attempt + 1, timeout_ms),
           updated_at: now
         ]
       )
@@ -304,10 +325,43 @@ defmodule EctoJob.JobQueue do
   end
 
   @doc """
-  Computes the expiry time for an `"IN_PROGRESS"` job based on the current time and attempt counter.
+  Transitions a job from `"IN_PROGRESS"` to `"RETRYING"`.
+
+  Updates the state to `"RETRYING"` and changes the schedule time to
+  differentiate an expired job from one that had an exception or an error.
+
   """
-  @spec progress_expiry(DateTime.t(), integer, integer) :: DateTime.t()
-  def progress_expiry(now = %DateTime{}, attempt, timeout_ms) do
+  @spec update_job_to_retrying(repo, job, DateTime.t(), integer) ::
+          {:ok, Ecto.Schema.t()} | {:error, String.t}
+  def update_job_to_retrying(repo, job  = %schema{}, now, timeout_ms) do
+    {count, results} =
+      repo.update_all(
+        Query.from(
+          j in schema,
+          where: j.id == ^job.id,
+          where: j.state == "IN_PROGRESS",
+          select: j
+        ),
+        [
+          set: [
+            state: "RETRYING",
+            schedule: increase_time(now, job.attempt + 1, timeout_ms),
+            updated_at: now
+          ]
+        ]
+      )
+
+    case {count, results} do
+      {0, _} -> {:error, :wrong_state_when_retrying}
+      {1, [job]} -> {:ok, job}
+    end
+  end
+
+  @doc """
+  Computes the expiry time for an `"IN_PROGRESS"` and schedule time of "RETRYING" jobs based on the current time and attempt counter.
+  """
+  @spec increase_time(DateTime.t(), integer, integer) :: DateTime.t()
+  def increase_time(now = %DateTime{}, attempt, timeout_ms) do
     timeout_ms |> Kernel.*(attempt) |> Integer.floor_div(1000) |> advance_seconds(now)
   end
 

--- a/lib/ecto_job/producer.ex
+++ b/lib/ecto_job/producer.ex
@@ -149,6 +149,7 @@ defmodule EctoJob.Producer do
   def handle_info(:poll, state = %State{repo: repo, schema: schema, clock: clock}) do
     now = clock.()
     _ = JobQueue.fail_expired_jobs_at_max_attempts(repo, schema, now)
+    _ = JobQueue.fail_retrying_jobs_at_max_attempts(repo, schema, now)
     activate_jobs(repo, schema, now)
     dispatch_jobs(state, now)
   end

--- a/lib/ecto_job/worker.ex
+++ b/lib/ecto_job/worker.ex
@@ -41,7 +41,7 @@ defmodule EctoJob.Worker do
     end
   end
 
-  @spec run_queue(Config.t, EctoJob.JobQueue.job()) :: {:ok, EctoJob.JobQueue.job()} | {:error, any()}
+  @spec run_queue(Config.t, EctoJob.JobQueue.job()) :: any()
   defp run_queue(%Config{repo: repo, retrying_timeout: timeout}, job = %queue{}) do
     try do
       queue.perform(JobQueue.initial_multi(job), job.params)
@@ -49,7 +49,7 @@ defmodule EctoJob.Worker do
       e ->
         stacktrace = System.stacktrace()
 
-        JobQueue.update_job_to_retrying(repo, job, DateTime.utc_now(), timeout)
+        _ = JobQueue.update_job_to_retrying(repo, job, DateTime.utc_now(), timeout)
 
         reraise(e, stacktrace)
     end

--- a/test/job_queue_test.exs
+++ b/test/job_queue_test.exs
@@ -102,6 +102,23 @@ defmodule EctoJob.JobQueueTest do
       assert count == 0
       assert Repo.get(EctoJob.Test.JobQueue, job.id).state == "RESERVED"
     end
+
+    test "Updates a scheduled RETRYING job to AVAILABLE" do
+      schedule = DateTime.from_naive!(~N[2017-08-17T12:23:34.000000Z], "Etc/UTC")
+      now = DateTime.from_naive!(~N[2017-08-17T12:24:00.000000Z], "Etc/UTC")
+
+      %{id: id} =
+        EctoJob.Test.JobQueue.new(%{})
+        |> Map.put(:state, "RETRYING")
+        |> Map.put(:schedule, schedule)
+        |> Repo.insert!()
+
+      count = EctoJob.JobQueue.activate_scheduled_jobs(Repo, EctoJob.Test.JobQueue, now)
+
+      assert count == 1
+      assert Repo.get(EctoJob.Test.JobQueue, id).state == "AVAILABLE"
+    end
+
   end
 
   describe "JobQueue.activate_expired_jobs" do
@@ -185,6 +202,23 @@ defmodule EctoJob.JobQueueTest do
         |> Repo.insert!()
 
       count = EctoJob.JobQueue.fail_expired_jobs_at_max_attempts(Repo, EctoJob.Test.JobQueue, now)
+
+      assert count == 1
+      assert %{state: "FAILED"} = Repo.get(EctoJob.Test.JobQueue, id)
+    end
+  end
+
+  describe "JobQueue.fail_retrying_jobs_at_max_attempts" do
+    test "FAILS RETRYING jobs at max_attempts" do
+      now = DateTime.from_naive!(~N[2017-08-17T12:24:00.000000Z], "Etc/UTC")
+
+      %{id: id} =
+        EctoJob.Test.JobQueue.new(%{}, max_attempts: 10)
+        |> Map.put(:state, "RETRYING")
+        |> Map.put(:attempt, 10)
+        |> Repo.insert!()
+
+      count = EctoJob.JobQueue.fail_retrying_jobs_at_max_attempts(Repo, EctoJob.Test.JobQueue, now)
 
       assert count == 1
       assert %{state: "FAILED"} = Repo.get(EctoJob.Test.JobQueue, id)
@@ -316,6 +350,46 @@ defmodule EctoJob.JobQueueTest do
           now,
           @default_timeout
         )
+    end
+  end
+
+  describe "JobQueue.update_job_to_retrying" do
+    test "Does not update state if different than IN_PROGRESS" do
+      expiry = DateTime.from_naive!(~N[2017-08-17T12:23:34.000000Z], "Etc/UTC")
+      now = DateTime.from_naive!(~N[2017-08-17T12:20:00.000000Z], "Etc/UTC")
+
+      job =
+        EctoJob.Test.JobQueue.new(%{})
+        |> Map.put(:state, "AVAILABLE")
+        |> Map.put(:expires, expiry)
+        |> Repo.insert!()
+
+      assert {:error, :wrong_state_when_retrying} = EctoJob.JobQueue.update_job_to_retrying(Repo, job, now, @default_timeout)
+
+      assert job.state == "AVAILABLE"
+      assert job.attempt == 0
+    end
+
+    test "Moves from IN_PROGRESS to RETRYING and increase the schedule" do
+      expiry = DateTime.from_naive!(~N[2017-08-17T12:23:34.000000Z], "Etc/UTC")
+      schedule = DateTime.from_naive!(~N[2017-08-17T12:23:34.000000Z], "Etc/UTC")
+      now = DateTime.from_naive!(~N[2017-08-17T12:20:00.000000Z], "Etc/UTC")
+
+      job =
+        EctoJob.Test.JobQueue.new(%{})
+        |> Map.put(:state, "IN_PROGRESS")
+        |> Map.put(:attempt, 1)
+        |> Map.put(:schedule, schedule)
+        |> Map.put(:expires, expiry)
+        |> Repo.insert!()
+
+      {:ok, new_job} = EctoJob.JobQueue.update_job_to_retrying(Repo, job, now, @default_timeout)
+
+      assert new_job.state == "RETRYING"
+      assert new_job.attempt == 1
+      assert DateTime.compare(expiry, new_job.expires) == :eq
+      assert DateTime.compare(schedule, new_job.schedule) == :lt
+      assert Repo.all(Query.from(EctoJob.Test.JobQueue, where: [state: "IN_PROGRESS"])) == []
     end
   end
 end

--- a/test/support/exception_job_queue.ex
+++ b/test/support/exception_job_queue.ex
@@ -1,0 +1,9 @@
+defmodule EctoJob.Test.ExceptionJobQueue do
+  # credo:disable-for-this-file
+
+  use EctoJob.JobQueue, table_name: "jobs"
+
+  def perform(_multi, _params) do
+    raise "Exception"
+  end
+end

--- a/test/support/job_queue.ex
+++ b/test/support/job_queue.ex
@@ -5,5 +5,7 @@ defmodule EctoJob.Test.JobQueue do
 
   def perform(multi, params) do
     IO.inspect({multi, params})
+
+    EctoJob.Test.Repo.transaction(multi)
   end
 end

--- a/test/support/transaction_fail_job_queue.ex
+++ b/test/support/transaction_fail_job_queue.ex
@@ -1,0 +1,11 @@
+defmodule EctoJob.Test.TransactionFailJobQueue do
+  # credo:disable-for-this-file
+
+  use EctoJob.JobQueue, table_name: "jobs"
+
+  def perform(multi, _params) do
+    multi
+    |> Ecto.Multi.run(:send, fn _,_ -> {:error, "Error"} end)
+    |> EctoJob.Test.Repo.transaction()
+  end
+end

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -7,7 +7,6 @@ defmodule EctoJob.WorkerTest do
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
-    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
 
     %{
       config: %EctoJob.Config{

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -1,0 +1,87 @@
+defmodule EctoJob.WorkerTest do
+  # credo:disable-for-this-file
+
+  use ExUnit.Case, async: true
+  alias EctoJob.Test.Repo
+  alias EctoJob.Worker
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+
+    %{
+      config: %EctoJob.Config{
+        repo: Repo,
+        max_demand: 100,
+        log: false,
+        log_level: :info,
+        poll_interval: 60_000,
+        retrying_timeout: 30_000,
+        reservation_timeout: 60_000,
+        execution_timeout: 300_000,
+        notifications_listen_timeout: 5_000}
+      }
+  end
+
+  describe "Worker.start_link" do
+    test "update job to the IN_PROGRESS state", %{config: config} do
+      expiry = DateTime.from_naive!(~N[2017-08-17T12:23:34.0000000Z], "Etc/UTC")
+      now = DateTime.from_naive!(~N[2017-08-17T12:20:00Z], "Etc/UTC")
+
+      job =
+        EctoJob.Test.JobQueue.new(%{})
+        |> Map.put(:state, "RESERVED")
+        |> Map.put(:expires, expiry)
+        |> Repo.insert!()
+
+      assert :ok == Worker.do_work(config, job, now)
+    end
+
+    test "return expired when the IN_PROGRESS job has expired", %{config: config} do
+      expiry = DateTime.from_naive!(~N[2017-08-17T11:23:34.0000000Z], "Etc/UTC")
+      now = DateTime.from_naive!(~N[2017-08-17T12:20:00Z], "Etc/UTC")
+
+      job =
+        EctoJob.Test.JobQueue.new(%{})
+        |> Map.put(:state, "RESERVED")
+        |> Map.put(:expires, expiry)
+        |> Repo.insert!()
+
+      assert {:error, :expired} == Worker.do_work(config, job, now)
+    end
+
+    test "changes the state to RETRYING when the multi transaction fails", %{config: config} do
+      expiry = DateTime.from_naive!(~N[2017-08-17T12:23:34.0000000Z], "Etc/UTC")
+      now = DateTime.from_naive!(~N[2017-08-17T12:20:00Z], "Etc/UTC")
+
+      job =
+        EctoJob.Test.TransactionFailJobQueue.new(%{})
+        |> Map.put(:state, "RESERVED")
+        |> Map.put(:expires, expiry)
+        |> Repo.insert!()
+
+      assert {:ok, _} = Worker.do_work(config, job, now)
+      assert Repo.get(EctoJob.Test.JobQueue, job.id).state == "RETRYING"
+    end
+
+    test "changes the state to RETRYING when perform raises an exception", %{config: config} do
+      expiry = DateTime.from_naive!(~N[2017-08-17T12:23:34.0000000Z], "Etc/UTC")
+      now = DateTime.from_naive!(~N[2017-08-17T12:20:00Z], "Etc/UTC")
+
+      job =
+        EctoJob.Test.ExceptionJobQueue.new(%{})
+        |> Map.put(:state, "RESERVED")
+        |> Map.put(:expires, expiry)
+        |> Repo.insert!()
+
+      try do
+        Worker.do_work(config, job, now)
+      rescue
+        _ -> assert Repo.get(EctoJob.Test.JobQueue, job.id).state == "RETRYING"
+      else
+        _ -> assert false
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Hi @mbuhot, I'm Gabriel from Sendle. We've been using EctoJob a lot in production and we found that we needed this extra state for dealing with failing jobs, so we made a few modifications. It's been working great so far, it's awesomely fast too! 

@seangeo told me that he talked with you about this change, but I thought a little introduction wouldn't do any harm :)

So, here we go with the technical bits:

### Problem trying to solve

With the current state machine is not possible to differentiate within a job that has crashed and a job that's taking a long time to run.

### Proposed Solution

Add a RETRYING state  when `queue.perform` fails in the worker, and change re-scheduling the job so it can be picked up by the `activate_scheduled_jobs` function. 

For falling back, the worker catches 2 different kind of failures from `queue.perform`, exceptions and transaction failures. 

Thus, with this extra state, it should be possible to pick a RETRYING job and force a retry by changing it to AVAILABLE manually, ensuring that it's not a job that it's taking a long time to run

### New State Machine proposal

![ectojob retry state - improved 1](https://user-images.githubusercontent.com/2847315/50863556-cba5ef00-137d-11e9-9075-f40fe560f7d4.png)