### PR TITLE
Document availability and usage of `notify` option

### DIFF
--- a/lib/ecto_job/job_queue.ex
+++ b/lib/ecto_job/job_queue.ex
@@ -156,6 +156,7 @@ defmodule EctoJob.JobQueue do
        - `:schedule` : runs the job at the given `%DateTime{}`
        - `:max_attempts` : the maximum attempts for this job
        - `:priority` (integer): lower numbers run first; default is 0
+       - `:notify` (string): payload to use for Postgres notification upon job completion
       """
       @spec new(map, Keyword.t()) :: EctoJob.JobQueue.job()
       def new(params = %{}, opts \\ []) do


### PR DESCRIPTION
The `notify` string value option was not documented.  Added documentation for this option and it's usage.