### PR TITLE
Add ".failed" and ".retry" Postres notifications

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+[
+  import_deps: [:ecto],
+  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
+  subdirectories: []
+]

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,5 +18,4 @@ if Mix.env() == :test do
   config :ecto_job, ecto_repos: [EctoJob.Test.Repo]
 
   config :logger, level: :warn
-
 end

--- a/lib/ecto_job/job_queue.ex
+++ b/lib/ecto_job/job_queue.ex
@@ -286,7 +286,9 @@ defmodule EctoJob.JobQueue do
     |> Query.with_cte("available_jobs", as: ^available_jobs(schema, demand))
     |> Query.join(:inner, [job], a in "available_jobs", on: job.id == a.id)
     |> Query.select([job], job)
-    |> repo.update_all(set: [state: "RESERVED", expires: reservation_expiry(now, timeout_ms), updated_at: now])
+    |> repo.update_all(
+      set: [state: "RESERVED", expires: reservation_expiry(now, timeout_ms), updated_at: now]
+    )
   end
 
   @doc """

--- a/lib/ecto_job/job_queue.ex
+++ b/lib/ecto_job/job_queue.ex
@@ -363,7 +363,7 @@ defmodule EctoJob.JobQueue do
   otherwise the state is transitioned to `"RETRY"` and changes the schedule time so the
   job will be picked up again.
   """
-  @spec job_failed(repo, job, DateTime.t(), integer) :: {:ok, job} | :error
+  @spec job_failed(repo(), job(), DateTime.t(), integer) :: {:ok, job} | :error
   def job_failed(repo, job = %schema{}, now, retry_timeout_ms) do
     updates =
       if job.attempt >= job.max_attempts do
@@ -385,8 +385,12 @@ defmodule EctoJob.JobQueue do
       )
 
     case {count, results} do
-      {0, _} -> :error
-      {1, [job]} -> {:ok, job}
+      {0, _} ->
+        :error
+
+      {1, [job]} ->
+        notify_failed(repo, job, updates)
+        {:ok, job}
     end
   end
 
@@ -424,5 +428,31 @@ defmodule EctoJob.JobQueue do
     |> DateTime.to_unix()
     |> Kernel.+(seconds)
     |> DateTime.from_unix!()
+  end
+
+  @spec notify_failed(repo(), job(), Keyword.t()) :: :ok
+  defp notify_failed(_repo, _job = %{notify: nil}, _updates), do: :ok
+
+  defp notify_failed(
+         repo,
+         job = %{notify: _payload},
+         _updates = [state: "RETRY", schedule: _]
+       ) do
+    do_notify_failed(repo, job, "retry")
+  end
+
+  defp notify_failed(
+         repo,
+         job = %{notify: _payload},
+         _updates = [state: "FAILED", expires: _]
+       ) do
+    do_notify_failed(repo, job, "failed")
+  end
+
+  @spec do_notify_failed(repo(), job(), binary()) :: :ok
+  defp do_notify_failed(repo, _job = %queue{notify: payload}, event) do
+    topic = queue.__schema__(:source) <> "." <> event
+    repo.query("SELECT pg_notify($1, $2)", [topic, payload])
+    :ok
   end
 end

--- a/lib/ecto_job/migrations.ex
+++ b/lib/ecto_job/migrations.ex
@@ -89,9 +89,11 @@ defmodule EctoJob.Migrations do
           add(:max_attempts, :integer, null: false, default: 5)
           add(:params, :map, null: false)
           add(:notify, :string)
+
           if version >= 3 do
             add(:priority, :integer, null: false, default: 0)
           end
+
           timestamps(timestamp_opts)
         end
 
@@ -99,6 +101,7 @@ defmodule EctoJob.Migrations do
         case version do
           2 ->
             create(index(name, [:schedule, :id]))
+
           3 ->
             create(index(name, [:priority, :schedule, :id]))
         end

--- a/lib/ecto_job/worker_supervisor.ex
+++ b/lib/ecto_job/worker_supervisor.ex
@@ -12,7 +12,7 @@ defmodule EctoJob.WorkerSupervisor do
    - `config` : The JobQueue configuration, used for Repo, Logging options
    - `subscribe_opts` : Should contain [{producer_name, max_demand: max_demand}]
   """
-  @spec start_link(config: Config.t, subscribe_to: Keyword.t()) :: Supervisor.on_start()
+  @spec start_link(config: Config.t(), subscribe_to: Keyword.t()) :: Supervisor.on_start()
   def start_link(config: config, subscribe_to: subscribe_opts) do
     children = [
       worker(Worker, [config], restart: :temporary)

--- a/test/support/transaction_fail_job_queue.ex
+++ b/test/support/transaction_fail_job_queue.ex
@@ -5,7 +5,7 @@ defmodule EctoJob.Test.TransactionFailJobQueue do
 
   def perform(multi, _params) do
     multi
-    |> Ecto.Multi.run(:send, fn _,_ -> {:error, "Error"} end)
+    |> Ecto.Multi.run(:send, fn _, _ -> {:error, "Error"} end)
     |> EctoJob.Test.Repo.transaction()
   end
 end


### PR DESCRIPTION
Currently, EctoJob only sends a ".completed" PostgreSQL notification.  This changeset will have EctoJob send two new notification events: ".retry" and ".failed".

This will allow users to `LISTEN` for these events and take action when a job fails and is re-queued as well as when a job fails for the last time.