### PR TITLE
Add support for `params` as Erlang/Elixir term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+# 3.1.0
+
+Version 3.1.0 adds support for job params as an Elixir/Erlang term.
+You can insert any arbitrary Elixir/Erlang term into the queue:
+
+```elixir
+{"SendEmail", "jonas@gmail.com", "Welcome!"}
+|> MyApp.JobQueue.new()
+|> MyApp.Repo.insert()
+```
+
+You should use the option `:params_type` when defining your queue module:
+
+```elixir
+defmodule MyJobQueue do
+  use EctoJob.JobQueue, table_name: "jobs", params_type: :binary
+  # ...
+end
+```
+
+Possible values of the option are: `:map` (default) and `:binary` (for storing Elixir/Erlang terms).
+
+You should use the same option when setting up the migration:
+
+```elixir
+@ecto_job_version 3
+
+def up do
+  EctoJob.Migrations.Install.up()
+  EctoJob.Migrations.up("jobs", version: @ecto_job_version, params_type: :binary)
+end
+```
+
+
 # 3.0.0
 
 Version 3.0 adds support for prioritizing jobs within each job queue.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ defmodule MyApp.Repo.Migrations.UpdateJobQueue do
 end
 ```
 
+
+
 Add a module for the queue, mix in `EctoJob.JobQueue`.
 This will declare an `Ecto.Schema` to use with the table created in the migration, and a `start_link` function allowing the worker supervision tree to be started conveniently.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A transactional job queue built with Ecto, PostgreSQL and GenStage
 Add `:ecto_job` to your `dependencies`
 
 ```elixir
-  {:ecto_job, "~> 3.0"}
+  {:ecto_job, "~> 3.1"}
 ```
 
 ## Installation
@@ -144,7 +144,7 @@ or
 |> MyApp.Repo.insert()
 ```
 
-In this case the `params` field in the schema will by of the `:binary` type (`bytea` in the PostgreSQL table).
+In this case the `params` field in the schema will be of the `:binary` type (`bytea` in the PostgreSQL table).
 
 
 A job can be inserted with optional params:

--- a/README.md
+++ b/README.md
@@ -127,6 +127,26 @@ A job can be inserted into the Repo directly by constructing a job with the `new
 |> MyApp.Repo.insert()
 ```
 
+By default, the job is a map, which corresponds to the `params` field of the type `:map` in the queue schema
+(`jsonb` if seen in the PostgreSQL table).  It can also be any Elixir/Erlang term:
+
+```elixir
+{"SendEmail", "joe@gmail.com", "Welcome!"}
+|> MyApp.JobQueue.new()
+|> MyApp.Repo.insert()
+```
+
+or
+
+```elixir
+|> %MyStruct{}
+|> MyApp.JobQueue.new()
+|> MyApp.Repo.insert()
+```
+
+In this case the `params` field in the schema will by of the `:binary` type (`bytea` in the PostgreSQL table).
+
+
 A job can be inserted with optional params:
 
 - `:schedule` : runs the job at the given `%DateTime{}`. The default value is `DateTime.utc_now()`.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ defmodule MyApp.Repo.Migrations.CreateJobQueue do
 end
 ```
 
+By default, a job holds a map of arbitrary data (which corresponds to a `jsonb` field in the table).
+If you want to store an arbitrary Elixir/Erlang term in the job (`bytea` in the table),
+you can set up the `params_type` option:
+
+```
+  def up do
+    EctoJob.Migrations.Install.up()
+    EctoJob.Migrations.CreateJobTable.up("jobs", version: @ecto_job_version, params_type: :binary)
+  end
+```
+
 ### Upgrading to version 3.0
 
 To upgrade your project to 3.0 version of `ecto_job` you must add a migration to update the pre-existent job queue tables:
@@ -81,6 +92,14 @@ This will declare an `Ecto.Schema` to use with the table created in the migratio
 ```elixir
 defmodule MyApp.JobQueue do
   use EctoJob.JobQueue, table_name: "jobs"
+end
+```
+
+For jobs being Elixir/Erlang terms, you should add the `:params_type` option:
+
+```elixir
+defmodule MyApp.JobQueue do
+  use EctoJob.JobQueue, table_name: "jobs", params_type: :binary
 end
 ```
 
@@ -127,8 +146,7 @@ A job can be inserted into the Repo directly by constructing a job with the `new
 |> MyApp.Repo.insert()
 ```
 
-By default, the job is a map, which corresponds to the `params` field of the type `:map` in the queue schema
-(`jsonb` if seen in the PostgreSQL table).  It can also be any Elixir/Erlang term:
+For inserting any arbitrary Elixir/Erlang term:
 
 ```elixir
 {"SendEmail", "joe@gmail.com", "Welcome!"}
@@ -143,9 +161,6 @@ or
 |> MyApp.JobQueue.new()
 |> MyApp.Repo.insert()
 ```
-
-In this case the `params` field in the schema will be of the `:binary` type (`bytea` in the PostgreSQL table).
-
 
 A job can be inserted with optional params:
 

--- a/lib/ecto_job/migrations.ex
+++ b/lib/ecto_job/migrations.ex
@@ -73,6 +73,7 @@ defmodule EctoJob.Migrations do
       prefix = Keyword.get(opts, :prefix)
       timestamp_opts = Keyword.get(opts, :timestamps, [])
       version = Keyword.get(opts, :version, 2)
+      params_type = Keyword.get(opts, :params_type, :map)
 
       _ =
         create table(name, opts) do
@@ -87,7 +88,7 @@ defmodule EctoJob.Migrations do
 
           add(:attempt, :integer, null: false, default: 0)
           add(:max_attempts, :integer, null: false, default: 5)
-          add(:params, :map, null: false)
+          add(:params, params_type, null: false)
           add(:notify, :string)
 
           if version >= 3 do
@@ -106,7 +107,7 @@ defmodule EctoJob.Migrations do
             create(index(name, [:schedule, :id]))
 
           3 ->
-            create(index(name, [:priority, :schedule, :id]))
+            create(index(name, [:priority, :schedule, :id], prefix: prefix))
         end
 
       execute("""

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule EctoJob.Mixfile do
   use Mix.Project
 
-  @version "3.0.0"
+  @version "3.1.0"
   @url "https://github.com/mbuhot/ecto_job"
 
   def project do

--- a/test/support/migrations/20170817092638_add_job_table.exs
+++ b/test/support/migrations/20170817092638_add_job_table.exs
@@ -11,6 +11,6 @@ defmodule EctoJob.Test.Repo.Migrations.AddJobTable do
 
   def down do
     CreateJobTable.down("jobs")
-    Intall.down()
+    Install.down()
   end
 end

--- a/test/support/migrations/20200603110510_add_job_table_binary.exs
+++ b/test/support/migrations/20200603110510_add_job_table_binary.exs
@@ -1,0 +1,23 @@
+defmodule EctoJob.Test.Repo.Migrations.AddJobTableBinary do
+  use Ecto.Migration
+  alias EctoJob.Migrations.{CreateJobTable, Install}
+
+  @ecto_job_version 3
+
+  def up do
+    execute("CREATE SCHEMA \"params_binary\";")
+    Install.up(prefix: "params_binary")
+
+    CreateJobTable.up("jobs",
+      version: @ecto_job_version,
+      prefix: "params_binary",
+      params_type: :binary
+    )
+  end
+
+  def down do
+    CreateJobTable.down("jobs", prefix: "parasm_binary")
+    Intall.down(prefix: "params_binary")
+    execute("DROP SCHEMA \"params_binary\";")
+  end
+end

--- a/test/support/migrations/20200603110510_add_job_table_binary.exs
+++ b/test/support/migrations/20200603110510_add_job_table_binary.exs
@@ -16,7 +16,7 @@ defmodule EctoJob.Test.Repo.Migrations.AddJobTableBinary do
   end
 
   def down do
-    CreateJobTable.down("jobs", prefix: "parasm_binary")
+    CreateJobTable.down("jobs", prefix: "params_binary")
     Intall.down(prefix: "params_binary")
     execute("DROP SCHEMA \"params_binary\";")
   end

--- a/test/support/params_binary_job_queue.ex
+++ b/test/support/params_binary_job_queue.ex
@@ -1,0 +1,8 @@
+defmodule EctoJob.Test.ParamsBinaryJobQueue do
+  @moduledoc false
+  use EctoJob.JobQueue, table_name: "jobs", schema_prefix: "params_binary", params_type: :binary
+
+  def perform(multi, _params) do
+    EctoJob.Test.Repo.transaction(multi)
+  end
+end


### PR DESCRIPTION
Very often it is useful to have an ability to pass an Erlang/Elixir term through the queue. For example, if you have an Elixir struct that you want to pass from a publisher to a subscriber, you could avoid converting it to JSON and back by storing a native serialized Erlang term in the table. It can make things more convenient for the publisher/subscriber mechanizm and it is generally faster than converting to/from JSON.