### PR TITLE
Adapt JobQueue typespecs to params_type

### DIFF
--- a/lib/ecto_job/job_queue/helpers.ex
+++ b/lib/ecto_job/job_queue/helpers.ex
@@ -1,0 +1,6 @@
+defmodule EctoJob.JobQueue.Helpers do
+  @moduledoc false
+
+  def __serialize_params__(params, :map) when is_map(params), do: params
+  def __serialize_params__(params, :binary), do: :erlang.term_to_binary(params)
+end


### PR DESCRIPTION
Depending on whether params type is map or binary, JobQueue generated module should have different typespecs