### PR TITLE
Add custom type for JobQueue params

### DIFF
--- a/lib/ecto_job/job_queue/helpers.ex
+++ b/lib/ecto_job/job_queue/helpers.ex
@@ -1,6 +1,0 @@
-defmodule EctoJob.JobQueue.Helpers do
-  @moduledoc false
-
-  def __serialize_params__(params, :map) when is_map(params), do: params
-  def __serialize_params__(params, :binary), do: :erlang.term_to_binary(params)
-end

--- a/lib/ecto_job/job_queue/json_params.ex
+++ b/lib/ecto_job/job_queue/json_params.ex
@@ -1,0 +1,20 @@
+defmodule EctoJob.JobQueue.JsonParams do
+  @moduledoc """
+  Job queue parameters as Json
+  """
+  use Ecto.Type
+
+  def type, do: :map
+
+  def cast(data) when is_map(data), do: {:ok, data}
+
+  def cast(_), do: :error
+
+  def load(data) when is_map(data), do: {:ok, data}
+
+  def load(_), do: :error
+
+  def dump(data) when is_map(data), do: {:ok, data}
+
+  def dump(_), do: :error
+end

--- a/lib/ecto_job/job_queue/term_params.ex
+++ b/lib/ecto_job/job_queue/term_params.ex
@@ -1,0 +1,24 @@
+defmodule EctoJob.JobQueue.TermParams do
+  @moduledoc """
+  Job queue parameters as Json
+  """
+  use Ecto.Type
+
+  def type, do: :binary
+
+  def cast(data), do: {:ok, data}
+
+  def load(data) when is_binary(data) do
+    {:ok, :erlang.binary_to_term(data)}
+  rescue
+    ArgumentError -> :error
+  end
+
+  def load(_), do: :error
+
+  def dump(data) do
+    {:ok, :erlang.term_to_binary(data)}
+  rescue
+    _ -> :error
+  end
+end

--- a/lib/ecto_job/migrations.ex
+++ b/lib/ecto_job/migrations.ex
@@ -171,6 +171,7 @@ defmodule EctoJob.Migrations do
     """
     def up(3, name, opts \\ []) do
       prefix = Keyword.get(opts, :prefix)
+
       alter table(name, prefix: prefix) do
         add(:priority, :integer, null: false, default: 0)
       end


### PR DESCRIPTION
By using custom Ecto types for params, they can be
serialized/deserialized by Ecto.

In particular, erlang terms are deserialized from the database.