### PR TITLE
bug: Fix params type definition with :map option

### DIFF
--- a/lib/ecto_job/job_queue.ex
+++ b/lib/ecto_job/job_queue.ex
@@ -102,7 +102,7 @@ defmodule EctoJob.JobQueue do
 
       params_spec =
         case params_type do
-          EctoJob.JobQueue.JsonParams -> :map
+          EctoJob.JobQueue.JsonParams -> {:map, [], []}
           EctoJob.JobQueue.TermParams -> {:term, [], []}
         end
 


### PR DESCRIPTION
Before this change, EctoJob.JobQueue.params() was being incorrectly set
to `:map`, instead of the desired `map()`, which causes Dialyzer to
think the contract any `EctoJob.JobQueue` function whose `@spec` uses
the `params()` type.